### PR TITLE
release: update release / update flow, generated install.sh

### DIFF
--- a/internal/cli/command/root.go
+++ b/internal/cli/command/root.go
@@ -1,6 +1,10 @@
 package command
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/EgorTarasov/cu/internal/update"
+
+	"github.com/spf13/cobra"
+)
 
 var RootCmd = &cobra.Command{
 	Use:   "cu",
@@ -9,4 +13,7 @@ var RootCmd = &cobra.Command{
 It provides access to courses, authentication, and data synchronization.`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
+	PersistentPostRun: func(_ *cobra.Command, _ []string) {
+		update.CheckForUpdate()
+	},
 }

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,0 +1,145 @@
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/EgorTarasov/cu/internal/version"
+)
+
+const (
+	repoAPI       = "https://api.github.com/repos/EgorTarasov/cu/releases/latest"
+	checkInterval = 7 * 24 * time.Hour
+	stateFile     = "update-check"
+	httpTimeout   = 3 * time.Second
+	semverParts   = 3
+	dirPerm       = 0o750
+	filePerm      = 0o600
+)
+
+type githubRelease struct {
+	TagName string `json:"tag_name"`
+	HTMLURL string `json:"html_url"`
+}
+
+func stateFilePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".cu-cli", stateFile), nil
+}
+
+func lastCheckTime() time.Time {
+	path, err := stateFilePath()
+	if err != nil {
+		return time.Time{}
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return time.Time{}
+	}
+	return info.ModTime()
+}
+
+func touchStateFile() {
+	path, err := stateFilePath()
+	if err != nil {
+		return
+	}
+	_ = os.MkdirAll(filepath.Dir(path), dirPerm)
+	_ = os.WriteFile(path, nil, filePerm)
+}
+
+// CheckForUpdate fetches the latest release from GitHub at most once per
+// checkInterval and prints a hint to stderr when a newer version is available.
+// It is best-effort: any network/parse error silently no-ops.
+func CheckForUpdate() {
+	if version.Version == "dev" {
+		return
+	}
+
+	if time.Since(lastCheckTime()) < checkInterval {
+		return
+	}
+
+	touchStateFile()
+
+	ctx, cancel := context.WithTimeout(context.Background(), httpTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, repoAPI, http.NoBody)
+	if err != nil {
+		return
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return
+	}
+
+	var release githubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return
+	}
+
+	latest := strings.TrimPrefix(release.TagName, "v")
+	current := strings.TrimPrefix(version.Version, "v")
+
+	if latest == current || !isNewer(latest, current) {
+		return
+	}
+
+	fmt.Fprintf(os.Stderr, "\nДоступна новая версия: %s (текущая: %s)\n",
+		release.TagName, version.Version)
+
+	if runtime.GOOS == "windows" {
+		fmt.Fprintf(os.Stderr, "Скачайте обновление: %s\n\n", release.HTMLURL)
+		return
+	}
+	fmt.Fprintln(os.Stderr,
+		"Обновите командой:\n"+
+			"  curl -fsSL https://raw.githubusercontent.com/EgorTarasov/cu/main/install.sh | sh")
+}
+
+func isNewer(a, b string) bool {
+	pa := splitVersion(a)
+	pb := splitVersion(b)
+	for i := range semverParts {
+		if pa[i] != pb[i] {
+			return pa[i] > pb[i]
+		}
+	}
+	return false
+}
+
+func splitVersion(v string) [semverParts]int {
+	var parts [semverParts]int
+	segments := strings.SplitN(v, ".", semverParts)
+	for i := 0; i < len(segments) && i < semverParts; i++ {
+		// strip any pre-release/build suffix (e.g. "3-rc1") by taking the leading digits.
+		s := segments[i]
+		for j, c := range s {
+			if c < '0' || c > '9' {
+				s = s[:j]
+				break
+			}
+		}
+		n, _ := strconv.Atoi(s)
+		parts[i] = n
+	}
+	return parts
+}


### PR DESCRIPTION
## Что добавляет PR

Авто-проверку новых версий CLI — раз в 7 дней `cu` тихо запрашивает
`api.github.com/repos/EgorTarasov/cu/releases/latest`, и если установленная
версия отстаёт — печатает в stderr подсказку с командой для обновления.

- `internal/update/update.go` — реализация:
  - Запрос к GitHub API с 3-секундным таймаутом через `context.WithTimeout` + `http.NewRequestWithContext`.
  - State-файл `~/.cu-cli/update-check` (права `0o600`) — mtime используется как таймстемп последней проверки, интервал 7 дней.
  - `splitVersion` парсит `MAJOR.MINOR.PATCH`, обрезает суффиксы (`-rc1`, `-dirty`).
  - Сборки с `version.Version == "dev"` пропускают проверку.
  - На Windows вместо install.sh-команды выводит ссылку на Releases.
- `internal/cli/command/root.go` — `PersistentPostRun` на `RootCmd` дёргает `update.CheckForUpdate()` после успешного выполнения любой команды.

## Локальная проверка

### 1. Update-flow срабатывает при отставании

Собрал бинарь с принудительной версией `v0.1.0` (ниже текущего латеста `v0.1.3`),
удалил state-файл, запустил субкомманду `version`:

```
$ go build -ldflags='-X main.ver=v0.1.0' -o /tmp/cu-old ./cmd/cu
$ rm -f ~/.cu-cli/update-check
$ /tmp/cu-old version
cu v0.1.0 (commit: unknown, built: unknown)

Доступна новая версия: v0.1.3 (текущая: v0.1.0)
Обновите командой:
  curl -fsSL https://raw.githubusercontent.com/EgorTarasov/cu/main/install.sh | sh
```

### 2. Кэширование 7 дней — без сети после первой проверки

После первой проверки state-файл создан (`0o600`), второй вызов завершается
за 7 ms без HTTP:

```
$ ls -la ~/.cu-cli/update-check
-rw-------@ ... /Users/.../.cu-cli/update-check

$ time /tmp/cu-old version
cu v0.1.0 (commit: unknown, built: unknown)
/tmp/cu-old version  0.00s user 0.00s system 80% cpu 0.007 total
```

### 3. `dev` сборки и `--help` не нагают

- При `version.Version == "dev"` функция возвращается без HTTP-запроса
  (важно для `go install` без LDFLAGS).
- `cu --help` и `cu --version` не триггерят `PersistentPostRun` (cobra
  выходит до Run/PostRun), поэтому быстрые help-вызовы не теряют ms на сеть.

### 4. Линт и тесты

- `make lint` — `0 issues` (gosec / mnd / noctx / golines все ок).
- `go test ./...` — все юнит-тесты зелёные.
- `make build` — собирается чисто.

## Известная проблема (вне scope PR)

Локальный smoke `install.sh` упёрся в 404 — у release `v0.1.3` на GitHub
**нулевой набор assets**, GoReleaser на этот тег не отрабатывал. Сам
скрипт ведёт себя правильно (детектит платформу, резолвит тег, печатает
404 от curl), но end-to-end установка через `install.sh` сейчас сломана
независимо от этого PR. Стоит отдельным issue/коммитом разобраться с
release-pipeline.

## Возможные follow-ups (намеренно вне этого PR)

- `CU_NO_UPDATE_CHECK=1` env-флаг для CI и MCP-режима.
- Юнит-тесты на `isNewer`/`splitVersion`.
- Skip баннера при `cu mcp` (stderr-спам может ломать JSON-RPC хосты).